### PR TITLE
Use /bin/sh, to avoid reliance on script exec bit

### DIFF
--- a/pkginstall.js
+++ b/pkginstall.js
@@ -43,15 +43,16 @@ download(url, version, dest, function (err, result) {
     icdir = path.join(inst_dir, '../instantclient');
   }
 
-  var args = [ icdir ];
+  var args = [ installer, icdir ];
+  var cmd = '/bin/sh';
 
 // console.log('DEBUG: Running command %s %s = ', installer, args);
   if (process.platform === 'win32') {
     installer = path.join(inst_dir, 'bin/installers/Windows/installer.bat');
     args = ['/c', installer];
-    installer = 'cmd';
+    cmd = 'cmd';
   }
-  var child = spawn(installer, args, {stdio: 'inherit'});
+  var child = spawn(cmd, args, {stdio: 'inherit'});
   child.on('exit', function () {
     process.exit(child.exitCode);
   });


### PR DESCRIPTION
`npm pack` doesn't guarantee preservance of the executable bit of
scripts, when done on Windows. This effects deploy from Windows to
Linux, see https://github.com/strongloop/strong-arc/issues/788

Untested, I spent about 15 minutes trying to figure out how to arrange things so I can execute pkginstall.js, and couldn't figure it out. Still, should work, and be safe under all conditions.

/to @raymondfeng 
/cc @rmg 